### PR TITLE
Initial development for Monster Gen API

### DIFF
--- a/controllers/monster.go
+++ b/controllers/monster.go
@@ -6,21 +6,33 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
+	uuid "github.com/satori/go.uuid"
+	"github.com/twosevenska/forge/mongo"
 	t "github.com/twosevenska/forge/types"
 )
 
-// CreateMonster adds a monster to DB
-func CreateMonster(c *gin.Context) {
+const (
+	monsterCollection = "critters"
+)
+
+// UpsertMonster adds a monster to DB
+func UpsertMonster(c *gin.Context) {
+	m := c.MustGet("mongo").(mongo.Client)
+
+	e := t.MonsterEntity{
+		BaseEntity: t.BaseEntity{
+			ID:   uuid.NewV4(),
+			Name: "test",
+		},
+	}
+
+	if err := m.UpsertMonster(e, monsterCollection); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": err.Error(),
+		})
+	}
 	c.JSON(http.StatusCreated, gin.H{
 		"message": "monster created successfully",
-	})
-}
-
-// UpdateMonster adds an existing monster in DB
-func UpdateMonster(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"message": "monster updated successfully",
 	})
 }
 

--- a/controllers/monster.go
+++ b/controllers/monster.go
@@ -33,10 +33,12 @@ func DeleteMonster(c *gin.Context) {
 func FetchMonsters(c *gin.Context) {
 	// TODO: insert DB fetch logic here
 	monsters := t.MonsterResult{
-		Items:       []t.MonsterEntity{},
-		TotalCount:  0,
-		CurrentPage: 1,
-		TotalPages:  1,
+		Items: []t.MonsterEntity{},
+		BaseResult: t.BaseResult{
+			TotalCount:  0,
+			CurrentPage: 1,
+			TotalPages:  1,
+		},
 	}
 
 	c.JSON(http.StatusOK, monsters)

--- a/controllers/monster.go
+++ b/controllers/monster.go
@@ -1,0 +1,43 @@
+// defines monster CRUD API
+
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	t "github.com/twosevenska/forge/types"
+)
+
+// CreateMonster adds a monster to DB
+func CreateMonster(c *gin.Context) {
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "monster created successfully",
+	})
+}
+
+// UpdateMonster adds an existing monster in DB
+func UpdateMonster(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"message": "monster updated successfully",
+	})
+}
+
+// DeleteMonster adds an existing monster in DB
+func DeleteMonster(c *gin.Context) {
+	c.Status(http.StatusNoContent)
+}
+
+// FetchMonsters gets existing monsters from DB
+func FetchMonsters(c *gin.Context) {
+	// TODO: insert DB fetch logic here
+	monsters := t.MonsterResult{
+		Items:       []t.MonsterEntity{},
+		TotalCount:  0,
+		CurrentPage: 1,
+		TotalPages:  1,
+	}
+
+	c.JSON(http.StatusOK, monsters)
+}

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,7 @@ import:
   version: ^1.1.4
 - package: gopkg.in/mgo.v2
 - package: github.com/kelseyhightower/envconfig
+- package: github.com/satori/go.uuid
 testImport:
 - package: github.com/smartystreets/goconvey
   version: ^1.6.2

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	t "github.com/twosevenska/forge/types"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 //TODO: Check all types in here and try to reorder them as needed
@@ -57,6 +59,20 @@ func Connect(sessionConf SessionConf) (*Client, error) {
 		Database: database,
 		session:  session,
 	}, nil
+}
+
+// UpsertMonster finds a monster and updates it or creates it
+func (c *Client) UpsertMonster(m t.MonsterEntity, collectionName string) error {
+	change := mgo.Change{
+		Update:    bson.M{"$set": m},
+		Upsert:    true,
+		ReturnNew: true,
+	}
+
+	var r t.MonsterEntity
+	_, err := c.Database.C(collectionName).Find(bson.M{"id": m.BaseEntity.ID}).Apply(change, &r)
+
+	return err
 }
 
 func createIndices(s *mgo.Session, sessionConf SessionConf) {

--- a/server/server.go
+++ b/server/server.go
@@ -7,16 +7,17 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/fvbock/endless"
 	"github.com/gin-gonic/gin"
+	"github.com/twosevenska/forge/controllers"
 	"github.com/twosevenska/forge/mongo"
 )
 
 // Config is a populated by env variables and Vault
 type Config struct {
 	Debug         bool     `envconfig:"debug" default:"false"`
-	MongoHosts    []string `envconfig:"mongo_hosts" default:"mongo.dev:27017"`
+	MongoHosts    []string `envconfig:"mongo_hosts" default:"127.0.0.1:27017"`
 	MongoDBName   string   `envconfig:"mongo_dbname" default:"forge"`
-	MongoUser     string   `envconfig:"mongo_user" default:"forge"`
-	MongoPassword string   `envconfig:"mongo_password" default:"forge1234"`
+	MongoUser     string   `envconfig:"mongo_user" default:""`
+	MongoPassword string   `envconfig:"mongo_password" default:""`
 }
 
 // ContextParams holds the objects required to initialise the server
@@ -55,10 +56,17 @@ func CreateRouter(contextParams *ContextParams) *gin.Engine {
 		})
 	})
 
-	/*api := r.Group("/forge/api", Auth())
+	api := r.Group("/forge/api", Auth())
 	{
-		//api.GET("/", controllers.INSERT_CONTROLLER_FUNCTION_HERE)
-	}*/
+		api.POST("/monsters", controllers.CreateMonster)
+
+		api.GET("/monsters", controllers.FetchMonsters)
+
+		api.PATCH("/monsters", controllers.UpdateMonster)
+
+		api.DELETE("/monsters", controllers.DeleteMonster)
+
+	}
 
 	if contextParams.Config.Debug {
 		// automatically add routers for net/http/pprof
@@ -91,6 +99,13 @@ func setupDB(c Config) *mongo.Client {
 		log.Fatalf("Failed to connect to MongoDB: %s", err)
 	}
 	return mongoClient
+}
+
+// Auth defines the base authentication logic
+func Auth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// TODO: implement authentication logic
+	}
 }
 
 // ContextObjects attaches backend clients to the API context

--- a/server/server.go
+++ b/server/server.go
@@ -58,11 +58,9 @@ func CreateRouter(contextParams *ContextParams) *gin.Engine {
 
 	api := r.Group("/forge/api", Auth())
 	{
-		api.POST("/monsters", controllers.CreateMonster)
+		api.PUT("/monsters", controllers.UpsertMonster)
 
 		api.GET("/monsters", controllers.FetchMonsters)
-
-		api.PATCH("/monsters", controllers.UpdateMonster)
 
 		api.DELETE("/monsters", controllers.DeleteMonster)
 

--- a/types/types.go
+++ b/types/types.go
@@ -6,9 +6,56 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+// BaseEntity describes a generic MongoDB row
 type BaseEntity struct {
 	ID        bson.Binary `bson:"_id,omitempty" json:"id"`
 	Name      string      `bson:"name" json:"name"`
 	CreatedAt time.Time   `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time   `bson:"updated_at" json:"updated_at"`
+}
+
+// MonsterEntity describes the general stats of a Monster
+type MonsterEntity struct {
+	BaseEntity
+	Strength            StatPair
+	Dexterity           StatPair
+	Constitution        StatPair
+	Intelligence        StatPair
+	Wisdom              StatPair
+	Charisma            StatPair
+	Challenge           int
+	ArmorClass          int
+	HitPoints           int
+	Speed               int
+	DamageResistances   []resistance
+	DamageImmunities    []immunity
+	ConditionImmunities []immunity
+	Sense               []sense
+	Languages           []string
+	Habilities          []hability
+	Actions             []action
+	Description         string
+	Picture             string
+}
+
+// StatPair describes a base attribute (such as strength) and its modifier
+type StatPair struct {
+	Attribute int
+	Modifier  int
+}
+
+// TODO: further specify habilities, resistances, immunities and senses
+
+type resistance struct{}
+type immunity struct{}
+type sense struct{}
+type hability struct{}
+type action struct{}
+
+// MonsterResult describes a an HTTP call response when fetching monsters
+type MonsterResult struct {
+	Items       []MonsterEntity
+	TotalCount  int64
+	CurrentPage int
+	TotalPages  int
 }

--- a/types/types.go
+++ b/types/types.go
@@ -3,15 +3,15 @@ package types
 import (
 	"time"
 
-	"gopkg.in/mgo.v2/bson"
+	"github.com/satori/go.uuid"
 )
 
 // BaseEntity describes a generic MongoDB row
 type BaseEntity struct {
-	ID        bson.Binary `bson:"_id,omitempty" json:"id"`
-	Name      string      `bson:"name" json:"name"`
-	CreatedAt time.Time   `bson:"created_at" json:"created_at"`
-	UpdatedAt time.Time   `bson:"updated_at" json:"updated_at"`
+	ID        uuid.UUID `bson:"_id,omitempty" json:"id"`
+	Name      string    `bson:"name" json:"name"`
+	CreatedAt time.Time `bson:"created_at" json:"created_at"`
+	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
 }
 
 // MonsterEntity describes the general stats of a Monster

--- a/types/types.go
+++ b/types/types.go
@@ -52,10 +52,16 @@ type sense struct{}
 type hability struct{}
 type action struct{}
 
-// Result describes a an HTTP call response when fetching monsters
-type Result struct {
-	Items       []MonsterEntity
+// BaseResult a generic HTTP call response when fetching data
+type BaseResult struct {
+	Items       []interface{}
 	TotalCount  int64
 	CurrentPage int
 	TotalPages  int
+}
+
+// MonsterResult describes a an HTTP call response when fetching monsters
+type MonsterResult struct {
+	BaseResult
+	Items []MonsterEntity
 }

--- a/types/types.go
+++ b/types/types.go
@@ -17,31 +17,31 @@ type BaseEntity struct {
 // MonsterEntity describes the general stats of a Monster
 type MonsterEntity struct {
 	BaseEntity
-	Strength            StatPair     `json:"strength"`
-	Dexterity           StatPair     `json:"dexterity"`
-	Constitution        StatPair     `json:"constitution"`
-	Intelligence        StatPair     `json:"intelligence"`
-	Wisdom              StatPair     `json:"wisdom"`
-	Charisma            StatPair     `json:"charisma"`
-	Challenge           int          `json:"challenge"`
-	ArmorClass          int          `json:"armor_class"`
-	HitPoints           int          `json:"hit_points"`
-	Speed               int          `json:"speed"`
-	DamageResistances   []resistance `json:"damage_resistances"`
-	DamageImmunities    []immunity   `json:"damage_immunities"`
-	ConditionImmunities []immunity   `json:"condition_immunities"`
-	Sense               []sense      `json:"sense"`
-	Languages           []string     `json:"languages"`
-	Habilities          []hability   `json:"habilities"`
-	Actions             []action     `json:"actions"`
-	Description         string       `json:"description"`
-	Picture             string       `json:"picture"`
+	Strength            StatPair     `bson:"strength" json:"strength"`
+	Dexterity           StatPair     `bson:"dexterity" json:"dexterity"`
+	Constitution        StatPair     `bson:"constitution" json:"constitution"`
+	Intelligence        StatPair     `bson:"intelligence" json:"intelligence"`
+	Wisdom              StatPair     `bson:"wisdom" json:"wisdom"`
+	Charisma            StatPair     `bson:"charisma" json:"charisma"`
+	Challenge           int          `bson:"challenge" json:"challenge"`
+	ArmorClass          int          `bson:"armor_class" json:"armor_class"`
+	HitPoints           int          `bson:"hit_points" json:"hit_points"`
+	Speed               int          `bson:"speed" json:"speed"`
+	DamageResistances   []resistance `bson:"damage_resistances" json:"damage_resistances"`
+	DamageImmunities    []immunity   `bson:"damage_immunities" json:"damage_immunities"`
+	ConditionImmunities []immunity   `bson:"condition_immunities" json:"condition_immunities"`
+	Sense               []sense      `bson:"sense" json:"sense"`
+	Languages           []string     `bson:"languages" json:"languages"`
+	Habilities          []hability   `bson:"habilities" json:"habilities"`
+	Actions             []action     `bson:"actions" json:"actions"`
+	Description         string       `bson:"description" json:"description"`
+	Picture             string       `bson:"picture" json:"picture"`
 }
 
 // StatPair describes a base attribute (such as strength) and its modifier
 type StatPair struct {
-	Attribute int `json:"attribute"`
-	Modifier  int `json:"modifier"`
+	Attribute int `bson:"attribute" json:"attribute"`
+	Modifier  int `bson:"modifier" json:"modifier"`
 }
 
 // TODO: further specify habilities, resistances, immunities and senses

--- a/types/types.go
+++ b/types/types.go
@@ -17,31 +17,31 @@ type BaseEntity struct {
 // MonsterEntity describes the general stats of a Monster
 type MonsterEntity struct {
 	BaseEntity
-	Strength            StatPair
-	Dexterity           StatPair
-	Constitution        StatPair
-	Intelligence        StatPair
-	Wisdom              StatPair
-	Charisma            StatPair
-	Challenge           int
-	ArmorClass          int
-	HitPoints           int
-	Speed               int
-	DamageResistances   []resistance
-	DamageImmunities    []immunity
-	ConditionImmunities []immunity
-	Sense               []sense
-	Languages           []string
-	Habilities          []hability
-	Actions             []action
-	Description         string
-	Picture             string
+	Strength            StatPair     `json:"strength"`
+	Dexterity           StatPair     `json:"dexterity"`
+	Constitution        StatPair     `json:"constitution"`
+	Intelligence        StatPair     `json:"intelligence"`
+	Wisdom              StatPair     `json:"wisdom"`
+	Charisma            StatPair     `json:"charisma"`
+	Challenge           int          `json:"challenge"`
+	ArmorClass          int          `json:"armor_class"`
+	HitPoints           int          `json:"hit_points"`
+	Speed               int          `json:"speed"`
+	DamageResistances   []resistance `json:"damage_resistances"`
+	DamageImmunities    []immunity   `json:"damage_immunities"`
+	ConditionImmunities []immunity   `json:"condition_immunities"`
+	Sense               []sense      `json:"sense"`
+	Languages           []string     `json:"languages"`
+	Habilities          []hability   `json:"habilities"`
+	Actions             []action     `json:"actions"`
+	Description         string       `json:"description"`
+	Picture             string       `json:"picture"`
 }
 
 // StatPair describes a base attribute (such as strength) and its modifier
 type StatPair struct {
-	Attribute int
-	Modifier  int
+	Attribute int `json:"attribute"`
+	Modifier  int `json:"modifier"`
 }
 
 // TODO: further specify habilities, resistances, immunities and senses
@@ -52,8 +52,8 @@ type sense struct{}
 type hability struct{}
 type action struct{}
 
-// MonsterResult describes a an HTTP call response when fetching monsters
-type MonsterResult struct {
+// Result describes a an HTTP call response when fetching monsters
+type Result struct {
 	Items       []MonsterEntity
 	TotalCount  int64
 	CurrentPage int


### PR DESCRIPTION
- Add boilerplate for controller CRUD on monsters 
- Add struct for monster entity and result

Next it should be to add monster CRUD logic on database layer.
The plan is to generalise this in such a way that it does not become tightly couple to database engine (currently in our case mongoDB)

Do note that I could not connect to mongoDB with the default credentials hence put those as empty strings.

Also these credentials should be on a separate configuration file that should remain unchecked from the repository due to possible security issues.